### PR TITLE
Use unformatted endpoint when retrieving invoices.

### DIFF
--- a/lib/zoho_invoice/invoice.rb
+++ b/lib/zoho_invoice/invoice.rb
@@ -22,7 +22,7 @@ module ZohoInvoice
     has_many :invoice_items
 
     def self.find_by_customer_id(client, id, options = {})
-      result_hash = client.get("/api/view/invoices/customer/#{id}").body
+      result_hash = client.get("/api/invoices/customer/#{id}").body
       potential_objects = result_hash['Response']["Invoices"]
       objects_to_hydrate = potential_objects["Invoice"] if potential_objects
       self.process_objects(client, objects_to_hydrate)
@@ -41,7 +41,7 @@ module ZohoInvoice
     end
 
     def self.find_unpaid_by_customer_id(client, id, options = {})
-      result_hash = client.get("/api/view/invoices/unpaid/customer/#{id}").body
+      result_hash = client.get("/api/invoices/unpaid/customer/#{id}").body
       potential_objects = result_hash['Response']["Invoices"]
       objects_to_hydrate = potential_objects["Invoice"] if potential_objects
       self.process_objects(client, objects_to_hydrate)

--- a/lib/zoho_invoice/version.rb
+++ b/lib/zoho_invoice/version.rb
@@ -1,3 +1,3 @@
 module ZohoInvoice
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/zoho_invoice/invoice_spec.rb
+++ b/spec/zoho_invoice/invoice_spec.rb
@@ -8,19 +8,19 @@ describe ZohoInvoice::Invoice do
     end
 
     it "should return an array if a customer has a single invoice" do
-      invoice_test('/api/view/invoices/customer/1234', 'successful_single_customer_response', 1, /Draft|Open|Closed|Overdue|Void/, :find_by_customer_id, @client, '1234')
+      invoice_test('/api/invoices/customer/1234', 'successful_single_customer_response', 1, /Draft|Open|Closed|Overdue|Void/, :find_by_customer_id, @client, '1234')
     end
 
     it "should return an array if a customer has multiple invoices" do
-      invoice_test('/api/view/invoices/customer/1234', 'successful_multiple_customer_response', 2, /Draft|Open|Closed|Overdue|Void/, :find_by_customer_id, @client, '1234')
+      invoice_test('/api/invoices/customer/1234', 'successful_multiple_customer_response', 2, /Draft|Open|Closed|Overdue|Void/, :find_by_customer_id, @client, '1234')
     end
 
     it "should return an empty array if a customer doesn't have any invoices" do
-      invoice_test('/api/view/invoices/customer/1234', 'successful_empty_customer_response', 0, //, :find_by_customer_id, @client, '1234')
+      invoice_test('/api/invoices/customer/1234', 'successful_empty_customer_response', 0, //, :find_by_customer_id, @client, '1234')
     end
 
     it "should return an error if theres an error" do
-      error_test('/api/view/invoices/customer/1234', '500_internal_server_error', :find_by_customer_id, 'Invalid value passed for XMLString', '2', '0', 500, @client, '1234')
+      error_test('/api/invoices/customer/1234', '500_internal_server_error', :find_by_customer_id, 'Invalid value passed for XMLString', '2', '0', 500, @client, '1234')
     end
 
     it "should return a hash if multiple customers are searched for" do
@@ -34,19 +34,19 @@ describe ZohoInvoice::Invoice do
     end
 
     it "should return an array if a customer has a single unpaid invoice" do
-      invoice_test('/api/view/invoices/unpaid/customer/1234', 'successful_unpaid_single_customer_response', 1, /Open|Overdue/, :find_unpaid_by_customer_id, @client, '1234')
+      invoice_test('/api/invoices/unpaid/customer/1234', 'successful_unpaid_single_customer_response', 1, /Open|Overdue/, :find_unpaid_by_customer_id, @client, '1234')
     end
 
     it "should return an array if a customer has multiple unpaid invoices" do
-      invoice_test('/api/view/invoices/unpaid/customer/1234', 'successful_unpaid_multiple_customer_response', 2, /Open|Overdue/, :find_unpaid_by_customer_id, @client, '1234')
+      invoice_test('/api/invoices/unpaid/customer/1234', 'successful_unpaid_multiple_customer_response', 2, /Open|Overdue/, :find_unpaid_by_customer_id, @client, '1234')
     end
 
     it "should return an empty array if a customer doesn't have any unpaid invoices" do
-      invoice_test('/api/view/invoices/unpaid/customer/1234', 'successful_unpaid_empty_customer_response', 0, //, :find_unpaid_by_customer_id, @client, '1234')
+      invoice_test('/api/invoices/unpaid/customer/1234', 'successful_unpaid_empty_customer_response', 0, //, :find_unpaid_by_customer_id, @client, '1234')
     end
 
     it "should return an error if theres an error" do
-      error_test('/api/view/invoices/unpaid/customer/1234', '500_internal_server_error', :find_unpaid_by_customer_id, 'Invalid value passed for XMLString', '2', '0', 500, @client, '1234')
+      error_test('/api/invoices/unpaid/customer/1234', '500_internal_server_error', :find_unpaid_by_customer_id, 'Invalid value passed for XMLString', '2', '0', 500, @client, '1234')
     end
 
      it "should return a hash if multiple customers are searched for" do


### PR DESCRIPTION
The unformatted API endpoint returns money and date values that are
easier to parse (i.e., `1100.00` instead of `$1,100.00`, and
`2013-04-30` instead of `30 Apr 2013`).
