### PR TITLE
Added more methods for retrieving invoices and customers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .config
 .yardoc
 .rvmrc
+.ruby-version
+.ruby-gemset
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/lib/zoho_invoice/customer.rb
+++ b/lib/zoho_invoice/customer.rb
@@ -17,9 +17,22 @@ module ZohoInvoice
       :shipping_state,
       :shipping_country,
       :shipping_fax,
-      :customer_id
+      :customer_id,
+      :active
 
     has_many :contacts
+
+    def self.all(client, options = {})
+      retrieve(client, '/api/customers') + retrieve(client, '/api/customers/inactive')
+    end
+
+    def self.all_active(client, options = {})
+      retrieve(client, '/api/customers').each { |c| c.active = true }
+    end
+
+    def self.all_inactive(client, options = {})
+      retrieve(client, '/api/customers/inactive').each { |c| c.active = false }
+    end
 
   end
 end

--- a/lib/zoho_invoice/customer.rb
+++ b/lib/zoho_invoice/customer.rb
@@ -23,7 +23,7 @@ module ZohoInvoice
     has_many :contacts
 
     def self.all(client, options = {})
-      retrieve(client, '/api/customers') + retrieve(client, '/api/customers/inactive')
+      self.all_active(client, options) + self.all_inactive(client, options)
     end
 
     def self.all_active(client, options = {})

--- a/lib/zoho_invoice/invoice.rb
+++ b/lib/zoho_invoice/invoice.rb
@@ -45,5 +45,9 @@ module ZohoInvoice
       return new_hash
     end
 
+    def self.find_all(client)
+      retrieve(client, '/api/invoices')
+    end
+
   end
 end

--- a/lib/zoho_invoice/invoice.rb
+++ b/lib/zoho_invoice/invoice.rb
@@ -22,14 +22,7 @@ module ZohoInvoice
     has_many :invoice_items
 
     def self.find_by_customer_id(client, id, options = {})
-      result_hash = client.get("/api/invoices/customer/#{id}").body
-      potential_objects = result_hash['Response']["Invoices"]
-      objects_to_hydrate = potential_objects["Invoice"] if potential_objects
-      self.process_objects(client, objects_to_hydrate)
-    rescue Faraday::Error::ClientError => e
-      if e.response[:body]
-        raise ZohoInvoice::Error::ClientError.from_response(e.response)
-      end
+      retrieve(client, "/api/invoices/customer/#{id}")
     end
 
     def self.find_by_multiple_customer_ids(client, ids, options={})
@@ -41,14 +34,7 @@ module ZohoInvoice
     end
 
     def self.find_unpaid_by_customer_id(client, id, options = {})
-      result_hash = client.get("/api/invoices/unpaid/customer/#{id}").body
-      potential_objects = result_hash['Response']["Invoices"]
-      objects_to_hydrate = potential_objects["Invoice"] if potential_objects
-      self.process_objects(client, objects_to_hydrate)
-    rescue Faraday::Error::ClientError => e
-      if e.response[:body]
-        raise ZohoInvoice::Error::ClientError.from_response(e.response)
-      end
+      retrieve(client, "/api/invoices/unpaid/customer/#{id}")
     end
 
     def self.find_unpaid_by_multiple_customer_ids(client, ids, options={})

--- a/lib/zoho_invoice/invoice.rb
+++ b/lib/zoho_invoice/invoice.rb
@@ -45,7 +45,7 @@ module ZohoInvoice
       return new_hash
     end
 
-    def self.find_all(client)
+    def self.all(client)
       retrieve(client, '/api/invoices')
     end
 

--- a/lib/zoho_invoice/version.rb
+++ b/lib/zoho_invoice/version.rb
@@ -1,3 +1,3 @@
 module ZohoInvoice
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end

--- a/spec/fixtures/successful_customers_response
+++ b/spec/fixtures/successful_customers_response
@@ -1,0 +1,7 @@
+<Response>
+  <Customers uri='/api/customers'>
+    <Customer>
+      <CustomerID>1</CustomerID>
+    </Customer>
+  </Customers>
+</Response>

--- a/spec/fixtures/successful_multiple_page_response_page_1
+++ b/spec/fixtures/successful_multiple_page_response_page_1
@@ -6,7 +6,14 @@
     </Invoice>
     <Invoice>
       <InvoiceID>2</InvoiceID>
-      <Status>Closed</Status>
+      <Status>Open</Status>
     </Invoice>
   </Invoices>
+  <PageContext>
+    <Page>1</Page>
+    <Per_Page>2</Per_Page>
+    <Total>3</Total>
+    <Total_Pages>2</Total_Pages>
+  </PageContext>
 </Response>
+

--- a/spec/fixtures/successful_multiple_page_response_page_2
+++ b/spec/fixtures/successful_multiple_page_response_page_2
@@ -1,0 +1,15 @@
+<Response>
+  <Invoices uri='/api/invoices/customer/1234'>
+    <Invoice>
+      <InvoiceID>3</InvoiceID>
+      <Status>Open</Status>
+    </Invoice>
+  </Invoices>
+  <PageContext>
+    <Page>2</Page>
+    <Per_Page>2</Per_Page>
+    <Total>3</Total>
+    <Total_Pages>2</Total_Pages>
+  </PageContext>
+</Response>
+

--- a/spec/fixtures/successful_single_customer_response
+++ b/spec/fixtures/successful_single_customer_response
@@ -1,5 +1,5 @@
 <Response>
-  <Invoices uri='/api/views/invoices/customer/1234'>
+  <Invoices uri='/api/invoices/customer/1234'>
     <Invoice>
       <InvoiceID>1</InvoiceID>
       <Status>Open</Status>

--- a/spec/fixtures/successful_unpaid_multiple_customer_response
+++ b/spec/fixtures/successful_unpaid_multiple_customer_response
@@ -1,5 +1,5 @@
 <Response>
-  <Invoices uri='/api/views/invoices/unpaid/customer/1234'>
+  <Invoices uri='/api/invoices/unpaid/customer/1234'>
     <Invoice>
       <InvoiceID>1</InvoiceID>
       <Status>Open</Status>

--- a/spec/fixtures/successful_unpaid_single_customer_response
+++ b/spec/fixtures/successful_unpaid_single_customer_response
@@ -1,5 +1,5 @@
 <Response>
-  <Invoices uri='/api/views/invoices/unpaid/customer/1234'>
+  <Invoices uri='/api/invoices/unpaid/customer/1234'>
     <Invoice>
       <InvoiceID>1</InvoiceID>
       <Status>Open</Status>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,23 @@ def multiple_invoice_test(fixture_to_use, num_customers, method_to_test, method_
   end
 end
 
+def customer_test(path, fixture_to_use, num_customers, active, method_to_test, *args)
+  stub_get(path).
+    with(:query => default_credentials).
+    to_return(:status => 200, :body => fixture(fixture_to_use), :headers => {:content_type => 'application/xml'})
+  result = ZohoInvoice::Customer.send(method_to_test, args[0])
+  expect(a_get(path).with(:query => default_credentials)).to have_been_made
+  expect(result.class).to eq(Array)
+  expect(result.length).to eq(num_customers)
+  if num_customers > 0
+    result.each_with_index do |r, i|
+      expect(r.class).to eq(ZohoInvoice::Customer)
+      expect(r.customer_id).to eq((i+1).to_s)
+      expect(r.active).to be(active)
+    end
+  end
+end
+
 def error_test(path, fixture_to_use, method_to_test, message, code, response_status, http_status, *args)
   stub_get(path).
     with(:query => default_credentials).

--- a/spec/zoho_invoice/customer_spec.rb
+++ b/spec/zoho_invoice/customer_spec.rb
@@ -31,6 +31,7 @@ describe ZohoInvoice::Customer do
 
       result.each_with_index do |r, i|
         expect(r.class).to eq(ZohoInvoice::Customer)
+        expect(r.active.to_s).to match(/true|false/)
       end
     end
   end

--- a/spec/zoho_invoice/customer_spec.rb
+++ b/spec/zoho_invoice/customer_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe ZohoInvoice::Customer do
+  describe "retrieving customers" do
+    before do
+      @client = ZohoInvoice::Client.new(default_credentials)
+    end
+
+    it "should return an array of active customers" do
+      customer_test('/api/customers', 'successful_customers_response', 1, true, :all_active, @client)
+    end
+
+    it "should return an array of inactive customers" do
+      customer_test('/api/customers/inactive', 'successful_customers_response', 1, false, :all_inactive, @client)
+    end
+
+    it "should return an array of all customers" do
+      stub_get('/api/customers').
+        with(:query => default_credentials).
+        to_return(:status => 200, :body => fixture('successful_customers_response'), :headers => {:content_type => 'application/xml'})
+
+      stub_get('/api/customers/inactive').
+        with(:query => default_credentials).
+        to_return(:status => 200, :body => fixture('successful_customers_response'), :headers => {:content_type => 'application/xml'})
+
+      result = ZohoInvoice::Customer.send('all', @client)
+      expect(a_get('/api/customers').with(:query => default_credentials)).to have_been_made
+      expect(a_get('/api/customers/inactive').with(:query => default_credentials)).to have_been_made
+      expect(result.class).to eq(Array)
+      expect(result.length).to eq(2)
+
+      result.each_with_index do |r, i|
+        expect(r.class).to eq(ZohoInvoice::Customer)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The biggest change is the extraction of the code that retrieves and hydrates invoices into a separate method on `ZohoInvoice::Base`. This code will almost always be the same for every resource (invoices, customers, etc.); only the API endpoint is different. Also, I noticed the current retrieval methods would fail to return all results if the response spanned across multiple pages. So, I added code to repeat the API call for each page and collect all the results.

Retrieval methods added:
- `ZohoInvoice::Invoice.all`
- `ZohoInvoice::Customer.all`
- `ZohoInvoice::Customer.all_active`
- `ZohoInvoice::Customer.all_inactive`

I've added tests for everything, and they should be passing.
